### PR TITLE
Correct openstack_catalog/settings.py file

### DIFF
--- a/openstack_catalog/settings.py
+++ b/openstack_catalog/settings.py
@@ -63,6 +63,7 @@ STATICFILES_FINDERS = (
 )
 
 INSTALLED_APPS = (
+    'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.staticfiles',
     'compressor',


### PR DESCRIPTION
Add missing 'django.contrib.auth' in openstack_catalog/settings.py.
